### PR TITLE
Ignoring development dependency since they are mostly not referenced

### DIFF
--- a/src/SolutionCop.DefaultRules.Tests/Data/NuGetPackagesUsage_6/UsesDevelopmentDependency.csproj
+++ b/src/SolutionCop.DefaultRules.Tests/Data/NuGetPackagesUsage_6/UsesDevelopmentDependency.csproj
@@ -1,0 +1,55 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{F460C2F8-FB97-4A93-A8C6-1C129665381D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>TargetFramework3_5</RootNamespace>
+    <AssemblyName>TargetFramework3_5</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="ApprovalTests">
+      <HintPath>..\packages\ApprovalTests.2.2\lib\ApprovalTests.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Class1.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/SolutionCop.DefaultRules.Tests/Data/NuGetPackagesUsage_6/packages.config
+++ b/src/SolutionCop.DefaultRules.Tests/Data/NuGetPackagesUsage_6/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="ApprovalTests" version="2.2" targetFramework="net35" />
+  <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net35" developmentDependency="true" />
+</packages>

--- a/src/SolutionCop.DefaultRules.Tests/NuGet/NuGetPackagesUsageRuleTests.cs
+++ b/src/SolutionCop.DefaultRules.Tests/NuGet/NuGetPackagesUsageRuleTests.cs
@@ -120,5 +120,12 @@
             var xmlConfig = XElement.Parse("<NuGetPackagesUsage enabled=\"false\"/>");
             ShouldPassAsDisabled(xmlConfig, new FileInfo(@"..\..\Data\NuGetPackagesUsage_2\UsesOnePackage.csproj").FullName);
         }
+
+        [Fact]
+        public void Should_pass_if_package_is_development_dependency()
+        {
+            var xmlConfig = XElement.Parse("<NuGetPackagesUsage/>");
+            ShouldPassNormally(xmlConfig, new FileInfo(@"..\..\Data\NuGetPackagesUsage_6\UsesDevelopmentDependency.csproj").FullName);
+        }
     }
 }

--- a/src/SolutionCop.DefaultRules/NuGet/NuGetPackagesUsageRule.cs
+++ b/src/SolutionCop.DefaultRules/NuGet/NuGetPackagesUsageRule.cs
@@ -62,11 +62,16 @@
                 {
                     var packageId = xmlUsedPackage.Attribute("id").Value;
                     var packageVersion = xmlUsedPackage.Attribute("version").Value;
+                    var developmentDependency = xmlUsedPackage.Attribute("developmentDependency")?.Value.Equals("true", StringComparison.OrdinalIgnoreCase) ?? false;
 
                     // TODO Simplify
                     if (exceptions.Contains(new Tuple<string, string>(projectFileName, null)) || exceptions.Contains(new Tuple<string, string>(null, packageId)) || exceptions.Contains(new Tuple<string, string>(projectFileName, packageId)))
                     {
                         Console.Out.WriteLine("DEBUG: Skipping package {0} as an exception in project {1}", packageId, projectFileName);
+                    }
+                    else if (developmentDependency)
+                    {
+                        Console.Out.WriteLine("DEBUG: Skipping package {0} as development dependency", packageId);
                     }
                     else
                     {


### PR DESCRIPTION
Пакеты с признаком developmentDependency не содержат в себе referenced assembly, и их всегда приходится добавлять в исключения, предлагаю внести изменения в правило NuGetPackagesUsageRule, что бы данные пакеты игнорировались при проверке.