### PR TITLE
Fixed rule that check StyleCop.MSBuild.targets in project

### DIFF
--- a/src/SolutionCop.DefaultRules/StyleCop/StyleCopEnabledRule.cs
+++ b/src/SolutionCop.DefaultRules/StyleCop/StyleCopEnabledRule.cs
@@ -48,7 +48,7 @@
             else
             {
                 var importedProjectPaths = xmlProject.Descendants(Namespace + "Import").Select(x => (string)x.Attribute("Project"));
-                if (!importedProjectPaths.Any(x => x.Contains("StyleCop.MSBuild.Targets") || x.Contains("Microsoft.SourceAnalysis.targets")))
+                if (!importedProjectPaths.Any(x => x.EndsWith("StyleCop.MSBuild.targets", StringComparison.OrdinalIgnoreCase) || x.Contains("Microsoft.SourceAnalysis.targets")))
                 {
                     yield return $"StyleCop is missing in project {projectFileName}";
                 }


### PR DESCRIPTION
Правило было регистрозависимым, и перестало работать, когда в пакете StyleCop.MSBuild изменили расширение проекта с .Targets на .targets